### PR TITLE
Added support for supplying a custom CertificateValidationCallback

### DIFF
--- a/src/Tests/ApprovalFiles/NoPublicApiChanges.Run.DotNet.verified.cs
+++ b/src/Tests/ApprovalFiles/NoPublicApiChanges.Run.DotNet.verified.cs
@@ -11,8 +11,10 @@ public static class PostgresqlExtensions
     public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema) { }
     public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
     public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+    public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, DbUp.Postgresql.PostgresqlConnectionOptions connectionOptions) { }
     public static void PostgresqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString) { }
     public static void PostgresqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+    public static void PostgresqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, DbUp.Postgresql.PostgresqlConnectionOptions connectionOptions) { }
     public static void PostgresqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, DbUp.Engine.Output.IUpgradeLog logger) { }
 }
 namespace DbUp.Postgresql
@@ -21,7 +23,14 @@ namespace DbUp.Postgresql
     {
         public PostgresqlConnectionManager(string connectionString) { }
         public PostgresqlConnectionManager(string connectionString, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public PostgresqlConnectionManager(string connectionString, DbUp.Postgresql.PostgresqlConnectionOptions connectionOptions) { }
         public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
+    }
+    public class PostgresqlConnectionOptions
+    {
+        public PostgresqlConnectionOptions() { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 ClientCertificate { get; set; }
+        public System.Net.Security.RemoteCertificateValidationCallback UserCertificateValidationCallback { get; set; }
     }
     public class PostgresqlObjectParser : DbUp.Support.SqlObjectParser, DbUp.Engine.ISqlObjectParser
     {

--- a/src/Tests/ApprovalFiles/NoPublicApiChanges.Run.Net.verified.cs
+++ b/src/Tests/ApprovalFiles/NoPublicApiChanges.Run.Net.verified.cs
@@ -11,8 +11,10 @@ public static class PostgresqlExtensions
     public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager, string schema) { }
     public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema) { }
     public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+    public static DbUp.Builder.UpgradeEngineBuilder PostgresqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString, string schema, DbUp.Postgresql.PostgresqlConnectionOptions connectionOptions) { }
     public static void PostgresqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString) { }
     public static void PostgresqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+    public static void PostgresqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, DbUp.Postgresql.PostgresqlConnectionOptions connectionOptions) { }
     public static void PostgresqlDatabase(this DbUp.SupportedDatabasesForEnsureDatabase supported, string connectionString, DbUp.Engine.Output.IUpgradeLog logger) { }
 }
 namespace DbUp.Postgresql
@@ -21,7 +23,14 @@ namespace DbUp.Postgresql
     {
         public PostgresqlConnectionManager(string connectionString) { }
         public PostgresqlConnectionManager(string connectionString, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public PostgresqlConnectionManager(string connectionString, DbUp.Postgresql.PostgresqlConnectionOptions connectionOptions) { }
         public override System.Collections.Generic.IEnumerable<string> SplitScriptIntoCommands(string scriptContents) { }
+    }
+    public class PostgresqlConnectionOptions
+    {
+        public PostgresqlConnectionOptions() { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 ClientCertificate { get; set; }
+        public System.Net.Security.RemoteCertificateValidationCallback UserCertificateValidationCallback { get; set; }
     }
     public class PostgresqlObjectParser : DbUp.Support.SqlObjectParser, DbUp.Engine.ISqlObjectParser
     {

--- a/src/dbup-postgresql/PostgresqlConnectionManager.cs
+++ b/src/dbup-postgresql/PostgresqlConnectionManager.cs
@@ -27,11 +27,23 @@ namespace DbUp.Postgresql
         /// <param name="connectionString">The PostgreSQL connection string.</param>
         /// <param name="certificate">Certificate for securing connection.</param>
         public PostgresqlConnectionManager(string connectionString, X509Certificate2 certificate)
+            : this(connectionString, new PostgresqlConnectionOptions
+            {
+                ClientCertificate = certificate
+            }) 
+        {
+        }
+
+        /// <summary>
+        /// Create a new PostgreSQL database connection 
+        /// </summary>
+        /// <param name="connectionString">The PostgreSQL connection string.</param>
+        /// <param name="connectionOptions">Custom options to apply on the created connection</param>
+        public PostgresqlConnectionManager(string connectionString, PostgresqlConnectionOptions connectionOptions)
             : base(new DelegateConnectionFactory(l =>
                 {
                     NpgsqlConnection databaseConnection = new NpgsqlConnection(connectionString);
-                    databaseConnection.ProvideClientCertificatesCallback +=
-                        certs => certs.Add(certificate);
+                    databaseConnection.ApplyConnectionOptions(connectionOptions);
 
                     return databaseConnection;
                 }

--- a/src/dbup-postgresql/PostgresqlConnectionOptions.cs
+++ b/src/dbup-postgresql/PostgresqlConnectionOptions.cs
@@ -1,0 +1,22 @@
+﻿using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+namespace DbUp.Postgresql
+{
+    /// <summary>
+    /// Options that will be applied on the created connection
+    /// </summary>
+    public class PostgresqlConnectionOptions
+    {
+        /// <summary>
+        /// Certificate for securing connection.
+        /// </summary>
+        public X509Certificate2 ClientCertificate { get; set; }
+
+        /// <summary>
+        //  Custom handler to verify the remote SSL certificate.
+        //  Ignored if Npgsql.NpgsqlConnectionStringBuilder.TrustServerCertificate is set.
+        /// </summary>
+        public RemoteCertificateValidationCallback UserCertificateValidationCallback { get; set; }
+    }
+}


### PR DESCRIPTION
# Checklist
- [x] I have read the [Contributing Guide](https://github.com/DbUp/DbUp/blob/master/CONTRIBUTING.md)
- [x] I have checked to ensure this does not introduce an unintended breaking changes
- [x] I have considered appropriate testing for my change

# Description
Our use case I'm trying to solve with this PR is that we need to implement custom Server Certificate validation in our code base. 

We already do this succesfully on all outgoing connections (both http and npgsql), but weren't able to with DbUp because the package only allows use to supply a connection string. We need to attach a handler on the created NpgsqlConnection object.

This PR adds an optional options object two the Extension methods with which you can supply a validation callback handler. Also, the existing option to supply a client certificate is supported. Existing APIs won't break, I've only added new methods.

Please let me know what you think.

(Linking issue #23)