### PR TITLE
Make it possible to change the master database name

### DIFF
--- a/src/dbup-postgresql/PostgresqlConnectionOptions.cs
+++ b/src/dbup-postgresql/PostgresqlConnectionOptions.cs
@@ -14,9 +14,14 @@ namespace DbUp.Postgresql
         public X509Certificate2 ClientCertificate { get; set; }
 
         /// <summary>
-        //  Custom handler to verify the remote SSL certificate.
-        //  Ignored if Npgsql.NpgsqlConnectionStringBuilder.TrustServerCertificate is set.
+        ///  Custom handler to verify the remote SSL certificate.
+        ///  Ignored if Npgsql.NpgsqlConnectionStringBuilder.TrustServerCertificate is set.
         /// </summary>
         public RemoteCertificateValidationCallback UserCertificateValidationCallback { get; set; }
+
+        /// <summary>
+        /// The database to connect to initially. Default is 'postgres'.
+        /// </summary>
+        public string MasterDatabaseName { get; set; } = "postgres";
     }
 }

--- a/src/dbup-postgresql/PostgresqlExtensions.cs
+++ b/src/dbup-postgresql/PostgresqlExtensions.cs
@@ -15,6 +15,10 @@ using Npgsql;
 /// </summary>
 public static class PostgresqlExtensions
 {
+    /// <summary>
+    /// Makes it possible to change the master database name, 
+    /// in case there is no database names "postgres".
+    /// </summary>
     public static string MasterDatabaseName { get; set; } = "postgres";
 
     /// <summary>

--- a/src/dbup-postgresql/PostgresqlExtensions.cs
+++ b/src/dbup-postgresql/PostgresqlExtensions.cs
@@ -16,12 +16,6 @@ using Npgsql;
 public static class PostgresqlExtensions
 {
     /// <summary>
-    /// Makes it possible to change the master database name, 
-    /// in case there is no database names "postgres".
-    /// </summary>
-    public static string MasterDatabaseName { get; set; } = "postgres";
-
-    /// <summary>
     /// Creates an upgrader for PostgreSQL databases.
     /// </summary>
     /// <param name="supported">Fluent helper type.</param>
@@ -165,7 +159,12 @@ public static class PostgresqlExtensions
         PostgresqlDatabase(supported, connectionString, logger, options);
     }
 
-    private static void PostgresqlDatabase(this SupportedDatabasesForEnsureDatabase supported, string connectionString, IUpgradeLog logger, PostgresqlConnectionOptions connectionOptions)
+    private static void PostgresqlDatabase(
+        this SupportedDatabasesForEnsureDatabase supported, 
+        string connectionString, 
+        IUpgradeLog logger, 
+        PostgresqlConnectionOptions connectionOptions
+    )
     {
         if (supported == null) throw new ArgumentNullException("supported");
 
@@ -185,7 +184,7 @@ public static class PostgresqlExtensions
             throw new InvalidOperationException("The connection string does not specify a database name.");
         }
 
-        masterConnectionStringBuilder.Database = MasterDatabaseName;
+        masterConnectionStringBuilder.Database = connectionOptions.MasterDatabaseName;
 
         var logMasterConnectionStringBuilder = new NpgsqlConnectionStringBuilder(masterConnectionStringBuilder.ConnectionString);
         if (!string.IsNullOrEmpty(logMasterConnectionStringBuilder.Password))

--- a/src/dbup-postgresql/PostgresqlExtensions.cs
+++ b/src/dbup-postgresql/PostgresqlExtensions.cs
@@ -15,6 +15,8 @@ using Npgsql;
 /// </summary>
 public static class PostgresqlExtensions
 {
+    public static string MasterDatabaseName { get; set; } = "postgres";
+
     /// <summary>
     /// Creates an upgrader for PostgreSQL databases.
     /// </summary>
@@ -145,7 +147,7 @@ public static class PostgresqlExtensions
             throw new InvalidOperationException("The connection string does not specify a database name.");
         }
 
-        masterConnectionStringBuilder.Database = "postgres";
+        masterConnectionStringBuilder.Database = MasterDatabaseName;
 
         var logMasterConnectionStringBuilder = new NpgsqlConnectionStringBuilder(masterConnectionStringBuilder.ConnectionString);
         if (!string.IsNullOrEmpty(logMasterConnectionStringBuilder.Password))


### PR DESCRIPTION
# Checklist
- [x] I have read the [Contributing Guide](https://github.com/DbUp/DbUp/blob/master/CONTRIBUTING.md)
- [x] I have checked to ensure this does not introduce an unintended breaking changes
- [x] I have considered appropriate testing for my change

# Description
I had to run a DbUp migration with a hosted PostgreSQL database at a cloud provider. 
Their setup does not provide a database named `postgres` which DbUp requires.

In this change, I introduced a public static property named `MasterDatabaseName` which has the default value `postgres`. If the user does not set it explicitly, nothing changes. In my case, I could just set it to the name of an existing db name (which is `defaultdb` in my case).

References:
- I saw that there was a similar PR two yeary ago:

  https://github.com/DbUp/DbUp/pull/605

  This approach did not work out because people relied on havinig DbUp set the master db name. My PR should bring together the best of both worlds and therefore make DbUp usable with a wider variety of hosted PG variations.

- This change would also fix https://github.com/DbUp/dbup-postgresql/issues/20