### PR TITLE
Target `net8` so we can use the latest version of Npgsql

### DIFF
--- a/src/dbup-postgresql/PostgresqlExtensions.cs
+++ b/src/dbup-postgresql/PostgresqlExtensions.cs
@@ -247,14 +247,13 @@ public static class PostgresqlExtensions
 
     internal static void ApplyConnectionOptions(this NpgsqlConnection connection, PostgresqlConnectionOptions connectionOptions)
     {
-        if (connectionOptions?.ClientCertificate != null)
+        connection.SslClientAuthenticationOptionsCallback = options =>
         {
-            connection.ProvideClientCertificatesCallback +=
-                certs => certs.Add(connectionOptions.ClientCertificate);
-        }
-        if (connectionOptions?.UserCertificateValidationCallback != null)
-        {
-            connection.UserCertificateValidationCallback = connectionOptions.UserCertificateValidationCallback;
-        }
+            if (connectionOptions?.ClientCertificate != null)
+                options.ClientCertificates = new X509Certificate2Collection(connectionOptions.ClientCertificate);
+
+            if (connectionOptions?.UserCertificateValidationCallback != null)
+                options.RemoteCertificateValidationCallback = connectionOptions.UserCertificateValidationCallback;
+        };
     }
 }

--- a/src/dbup-postgresql/dbup-postgresql.csproj
+++ b/src/dbup-postgresql/dbup-postgresql.csproj
@@ -6,7 +6,7 @@
     <Company>DbUp Contributors</Company>
     <Product>DbUp</Product>
     <Copyright>Copyright © DbUp Contributors 2015</Copyright>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>dbup-postgresql</AssemblyName>
     <RootNamespace>DbUp.Postgresql</RootNamespace>
     <PackageId>dbup-postgresql</PackageId>
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="dbup-core" Version="6.0.4" />
-    <PackageReference Include="Npgsql" Version="8.0.3" />
+    <PackageReference Include="Npgsql" Version="9.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Looks like `Npgsql` has dropped support for `netstandard2.0` so in order to keep on top of patches this library should do the same. Going to net8.0 as it's the only supported LTS.