### PR TITLE
Fix delimiter parsing

### DIFF
--- a/src/Tests/PostgresqlQueryParserTests.cs
+++ b/src/Tests/PostgresqlQueryParserTests.cs
@@ -47,6 +47,23 @@ public class PostgresqlQueryParserTests
                 'text';
                 SELECT '1'
                 """, 2)]
+    [InlineData("""
+                START TRANSACTION;
+
+                DO $EF$
+                BEGIN
+                    INSERT INTO "AspNetUsers" ("Id", "UserName")
+                    VALUES ('65fe2157-3214-4de5-8664-2648b67c530e', 'John');
+                END $EF$;
+
+                DO $EF$
+                BEGIN
+                    INSERT INTO "AspNetUsers" ("Id", "UserName")
+                    VALUES ('7cc03149-09e9-42eb-9554-d3ce3bed15bd', 'Jane');
+                END $EF$;
+
+                COMMIT;
+                """, 4)]
     public void split_into_statements(string sql, int statementCount, params string[] expected)
     {
         var results = ParseCommand(sql);

--- a/src/dbup-postgresql/PostgresqlQueryParser.cs
+++ b/src/dbup-postgresql/PostgresqlQueryParser.cs
@@ -239,7 +239,6 @@ internal static class PostgresqlQueryParser
             goto Finish;
         }
 
-        pos += dollarTagEnd + 1; // If the substring is found adjust the position to be relative to the entire string
         currCharOfs = pos + dollarTagEnd - dollarTagStart + 2;
         ch = '\0';
         goto None;


### PR DESCRIPTION
# Checklist
- [x] I have read the [Contributing Guide](https://github.com/DbUp/DbUp/blob/master/CONTRIBUTING.md)
- [x] I have checked to ensure this does not introduce an unintended breaking changes
- [x] I have considered appropriate testing for my change

# Description
SQL scripts are not correctly parsed into commands when there are delimiters.
Scripts generated by EF Core do not work correctly.

IndexOf return a position that is already relative to the entire string.

Close #29 