### PR TITLE
Use Postgres function to_regclass to check for existence of table

### DIFF
--- a/src/Tests/ApprovalFiles/DatabaseSupportTests.VerifyBasicSupport.approved.txt
+++ b/src/Tests/ApprovalFiles/DatabaseSupportTests.VerifyBasicSupport.approved.txt
@@ -1,12 +1,20 @@
 ﻿DB Operation: Open connection
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists
-DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'schemaversions'
+DB Operation: Execute scalar command: 
+        select case
+            when to_regclass('"schemaversions"') is not null then 1
+            else 0
+        end;
 DB Operation: Dispose command
 Info:         Journal table does not exist
 Info:         Executing Database Server script 'Script0001.sql'
 Info:         Checking whether journal table exists
-DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'schemaversions'
+DB Operation: Execute scalar command: 
+        select case
+            when to_regclass('"schemaversions"') is not null then 1
+            else 0
+        end;
 DB Operation: Dispose command
 Info:         Creating the "schemaversions" table
 DB Operation: Execute non query command: CREATE TABLE "schemaversions"

--- a/src/Tests/ApprovalFiles/DatabaseSupportTests.VerifyBasicSupport.approved.txt
+++ b/src/Tests/ApprovalFiles/DatabaseSupportTests.VerifyBasicSupport.approved.txt
@@ -3,7 +3,7 @@ Info:         Beginning database upgrade
 Info:         Checking whether journal table exists
 DB Operation: Execute scalar command: 
 select case
-    when to_regclass('"schemaversions"') is not null then 1
+    when pg_catalog.to_regclass('"schemaversions"') is not null then 1
     else 0
 end;
 DB Operation: Dispose command
@@ -12,7 +12,7 @@ Info:         Executing Database Server script 'Script0001.sql'
 Info:         Checking whether journal table exists
 DB Operation: Execute scalar command: 
 select case
-    when to_regclass('"schemaversions"') is not null then 1
+    when pg_catalog.to_regclass('"schemaversions"') is not null then 1
     else 0
 end;
 DB Operation: Dispose command

--- a/src/Tests/ApprovalFiles/DatabaseSupportTests.VerifyBasicSupport.approved.txt
+++ b/src/Tests/ApprovalFiles/DatabaseSupportTests.VerifyBasicSupport.approved.txt
@@ -2,19 +2,19 @@
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists
 DB Operation: Execute scalar command: 
-        select case
-            when to_regclass('"schemaversions"') is not null then 1
-            else 0
-        end;
+select case
+    when to_regclass('"schemaversions"') is not null then 1
+    else 0
+end;
 DB Operation: Dispose command
 Info:         Journal table does not exist
 Info:         Executing Database Server script 'Script0001.sql'
 Info:         Checking whether journal table exists
 DB Operation: Execute scalar command: 
-        select case
-            when to_regclass('"schemaversions"') is not null then 1
-            else 0
-        end;
+select case
+    when to_regclass('"schemaversions"') is not null then 1
+    else 0
+end;
 DB Operation: Dispose command
 Info:         Creating the "schemaversions" table
 DB Operation: Execute non query command: CREATE TABLE "schemaversions"

--- a/src/Tests/ApprovalFiles/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.approved.txt
+++ b/src/Tests/ApprovalFiles/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.approved.txt
@@ -2,19 +2,19 @@
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists
 DB Operation: Execute scalar command: 
-        select case
-            when to_regclass('"test"."TestSchemaVersions"') is not null then 1
-            else 0
-        end;
+select case
+    when to_regclass('"test"."TestSchemaVersions"') is not null then 1
+    else 0
+end;
 DB Operation: Dispose command
 Info:         Journal table does not exist
 Info:         Executing Database Server script 'Script0001.sql'
 Info:         Checking whether journal table exists
 DB Operation: Execute scalar command: 
-        select case
-            when to_regclass('"test"."TestSchemaVersions"') is not null then 1
-            else 0
-        end;
+select case
+    when to_regclass('"test"."TestSchemaVersions"') is not null then 1
+    else 0
+end;
 DB Operation: Dispose command
 Info:         Creating the "test"."TestSchemaVersions" table
 DB Operation: Execute non query command: CREATE TABLE "test"."TestSchemaVersions"

--- a/src/Tests/ApprovalFiles/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.approved.txt
+++ b/src/Tests/ApprovalFiles/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.approved.txt
@@ -3,7 +3,7 @@ Info:         Beginning database upgrade
 Info:         Checking whether journal table exists
 DB Operation: Execute scalar command: 
 select case
-    when to_regclass('"test"."TestSchemaVersions"') is not null then 1
+    when pg_catalog.to_regclass('"test"."TestSchemaVersions"') is not null then 1
     else 0
 end;
 DB Operation: Dispose command
@@ -12,7 +12,7 @@ Info:         Executing Database Server script 'Script0001.sql'
 Info:         Checking whether journal table exists
 DB Operation: Execute scalar command: 
 select case
-    when to_regclass('"test"."TestSchemaVersions"') is not null then 1
+    when pg_catalog.to_regclass('"test"."TestSchemaVersions"') is not null then 1
     else 0
 end;
 DB Operation: Dispose command

--- a/src/Tests/ApprovalFiles/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.approved.txt
+++ b/src/Tests/ApprovalFiles/DatabaseSupportTests.VerifyJournalCreationIfNameChanged.approved.txt
@@ -1,12 +1,20 @@
 ﻿DB Operation: Open connection
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists
-DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'TestSchemaVersions' and TABLE_SCHEMA = 'test'
+DB Operation: Execute scalar command: 
+        select case
+            when to_regclass('"test"."TestSchemaVersions"') is not null then 1
+            else 0
+        end;
 DB Operation: Dispose command
 Info:         Journal table does not exist
 Info:         Executing Database Server script 'Script0001.sql'
 Info:         Checking whether journal table exists
-DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'TestSchemaVersions' and TABLE_SCHEMA = 'test'
+DB Operation: Execute scalar command: 
+        select case
+            when to_regclass('"test"."TestSchemaVersions"') is not null then 1
+            else 0
+        end;
 DB Operation: Dispose command
 Info:         Creating the "test"."TestSchemaVersions" table
 DB Operation: Execute non query command: CREATE TABLE "test"."TestSchemaVersions"

--- a/src/Tests/ApprovalFiles/DatabaseSupportTests.VerifyVariableSubstitutions.approved.txt
+++ b/src/Tests/ApprovalFiles/DatabaseSupportTests.VerifyVariableSubstitutions.approved.txt
@@ -1,12 +1,20 @@
 ﻿DB Operation: Open connection
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists
-DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'schemaversions'
+DB Operation: Execute scalar command: 
+        select case
+            when to_regclass('"schemaversions"') is not null then 1
+            else 0
+        end;
 DB Operation: Dispose command
 Info:         Journal table does not exist
 Info:         Executing Database Server script 'Script0001.sql'
 Info:         Checking whether journal table exists
-DB Operation: Execute scalar command: select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = 'schemaversions'
+DB Operation: Execute scalar command: 
+        select case
+            when to_regclass('"schemaversions"') is not null then 1
+            else 0
+        end;
 DB Operation: Dispose command
 Info:         Creating the "schemaversions" table
 DB Operation: Execute non query command: CREATE TABLE "schemaversions"

--- a/src/Tests/ApprovalFiles/DatabaseSupportTests.VerifyVariableSubstitutions.approved.txt
+++ b/src/Tests/ApprovalFiles/DatabaseSupportTests.VerifyVariableSubstitutions.approved.txt
@@ -3,7 +3,7 @@ Info:         Beginning database upgrade
 Info:         Checking whether journal table exists
 DB Operation: Execute scalar command: 
 select case
-    when to_regclass('"schemaversions"') is not null then 1
+    when pg_catalog.to_regclass('"schemaversions"') is not null then 1
     else 0
 end;
 DB Operation: Dispose command
@@ -12,7 +12,7 @@ Info:         Executing Database Server script 'Script0001.sql'
 Info:         Checking whether journal table exists
 DB Operation: Execute scalar command: 
 select case
-    when to_regclass('"schemaversions"') is not null then 1
+    when pg_catalog.to_regclass('"schemaversions"') is not null then 1
     else 0
 end;
 DB Operation: Dispose command

--- a/src/Tests/ApprovalFiles/DatabaseSupportTests.VerifyVariableSubstitutions.approved.txt
+++ b/src/Tests/ApprovalFiles/DatabaseSupportTests.VerifyVariableSubstitutions.approved.txt
@@ -2,19 +2,19 @@
 Info:         Beginning database upgrade
 Info:         Checking whether journal table exists
 DB Operation: Execute scalar command: 
-        select case
-            when to_regclass('"schemaversions"') is not null then 1
-            else 0
-        end;
+select case
+    when to_regclass('"schemaversions"') is not null then 1
+    else 0
+end;
 DB Operation: Dispose command
 Info:         Journal table does not exist
 Info:         Executing Database Server script 'Script0001.sql'
 Info:         Checking whether journal table exists
 DB Operation: Execute scalar command: 
-        select case
-            when to_regclass('"schemaversions"') is not null then 1
-            else 0
-        end;
+select case
+    when to_regclass('"schemaversions"') is not null then 1
+    else 0
+end;
 DB Operation: Dispose command
 Info:         Creating the "schemaversions" table
 DB Operation: Execute non query command: CREATE TABLE "schemaversions"

--- a/src/Tests/ApprovalFiles/NoPublicApiChanges.Run.approved.cs
+++ b/src/Tests/ApprovalFiles/NoPublicApiChanges.Run.approved.cs
@@ -63,6 +63,7 @@ namespace DbUp.Postgresql
     {
         public PostgresqlTableJournal(System.Func<DbUp.Engine.Transactions.IConnectionManager> connectionManager, System.Func<DbUp.Engine.Output.IUpgradeLog> logger, string schema, string tableName) { }
         protected override string CreateSchemaTableSql(string quotedPrimaryKeyName) { }
+        protected override string DoesTableExistSql() { }
         protected override string GetInsertJournalEntrySql(string scriptName, string applied) { }
         protected override System.Data.IDbCommand GetInsertScriptCommand(System.Func<System.Data.IDbCommand> dbCommandFactory, DbUp.Engine.SqlScript script) { }
         protected override string GetJournalEntriesSql() { }

--- a/src/dbup-postgresql/PostgresqlTableJournal.cs
+++ b/src/dbup-postgresql/PostgresqlTableJournal.cs
@@ -4,7 +4,6 @@ using DbUp.Engine;
 using DbUp.Engine.Output;
 using DbUp.Engine.Transactions;
 using DbUp.Support;
-using Npgsql;
 
 namespace DbUp.Postgresql;
 
@@ -82,10 +81,10 @@ public class PostgresqlTableJournal : TableJournal
         string fqSchemaTableName = FqSchemaTableName.Replace("'", "''");
 
         string sql = $@"
-        select case
-            when to_regclass('{fqSchemaTableName}') is not null then 1
-            else 0
-        end;";
+select case
+    when to_regclass('{fqSchemaTableName}') is not null then 1
+    else 0
+end;";
 
         return sql;
     }

--- a/src/dbup-postgresql/PostgresqlTableJournal.cs
+++ b/src/dbup-postgresql/PostgresqlTableJournal.cs
@@ -82,7 +82,7 @@ public class PostgresqlTableJournal : TableJournal
 
         string sql = $@"
 select case
-    when to_regclass('{fqSchemaTableName}') is not null then 1
+    when pg_catalog.to_regclass('{fqSchemaTableName}') is not null then 1
     else 0
 end;";
 

--- a/src/dbup-postgresql/PostgresqlTableJournal.cs
+++ b/src/dbup-postgresql/PostgresqlTableJournal.cs
@@ -1,9 +1,10 @@
-using System;
+﻿using System;
 using System.Data;
 using DbUp.Engine;
 using DbUp.Engine.Output;
 using DbUp.Engine.Transactions;
 using DbUp.Support;
+using Npgsql;
 
 namespace DbUp.Postgresql;
 
@@ -73,5 +74,19 @@ public class PostgresqlTableJournal : TableJournal
     applied timestamp without time zone NOT NULL,
     CONSTRAINT {quotedPrimaryKeyName} PRIMARY KEY (schemaversionsid)
 )";
+    }
+
+    /// <inheritdoc/>
+    protected override string DoesTableExistSql()
+    {
+        string fqSchemaTableName = FqSchemaTableName.Replace("'", "''");
+
+        string sql = $@"
+        select case
+            when to_regclass('{fqSchemaTableName}') is not null then 1
+            else 0
+        end;";
+
+        return sql;
     }
 }


### PR DESCRIPTION
# Checklist
- [x] I have read the [Contributing Guide](https://github.com/DbUp/DbUp/blob/master/CONTRIBUTING.md)
- [x] I have checked to ensure this does not introduce an unintended breaking changes
- [x] I have considered appropriate testing for my change

# Description
* Addresses #2.
* Uses Postgres function `pg_catalog.to_regclass` to check for a table's existence. The performance is not dependent on the size of the user data tables in the database.
* Versions prior to Postgres 9.4 will not be able to support this functionality and 9.3 reached end of life in 2018.
* Fixed another issue where single quotes were not allowed in schema and table names.